### PR TITLE
fix(github-workflows): change git diff output path to diff.ansi

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ format('[GitHub Link](<{0}/{1}/commit/{2}>)', github.server_url, github.repository, github.sha) }}
       - name: Get formatted diff
         id: get_diff
-        uses: ILikePlayingGames/line-diff-action@v1.3
+        uses: ILikePlayingGames/line-diff-action@v3
         with:
           commit-hash: '@~'
           diff-algorithm: histogram

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -28,6 +28,7 @@ jobs:
           commit-hash: '@~'
           diff-algorithm: histogram
           delta-theme: discord
+          output-path: './diff.ansi'
       - name: Wrap diff in code block
         run: >-
           sed -i -e 's/`/\\`/g' -e '1i```ansi' -e '$a```\n' diff.ansi

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -23,12 +23,11 @@ jobs:
             ${{ format('[GitHub Link](<{0}/{1}/commit/{2}>)', github.server_url, github.repository, github.sha) }}
       - name: Get formatted diff
         id: get_diff
-        uses: ILikePlayingGames/line-diff-action@v3
+        uses: ILikePlayingGames/line-diff-action@v1.3
         with:
           commit-hash: '@~'
           diff-algorithm: histogram
           delta-theme: discord
-          output-path: './diff.ansi'
       - name: Wrap diff in code block
         run: >-
           sed -i -e 's/`/\\`/g' -e '1i```ansi' -e '$a```\n' diff.ansi

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -28,6 +28,8 @@ jobs:
           commit-hash: '@~'
           diff-algorithm: histogram
           delta-theme: discord
+      - name: Change diff file extension to ansi
+        run: mv diff.txt diff.ansi
       - name: Wrap diff in code block
         run: >-
           sed -i -e 's/`/\\`/g' -e '1i```ansi' -e '$a```\n' diff.ansi


### PR DESCRIPTION
This is required to match pull request #31

The changes are done by consulting the previous workflow's documentations https://github.com/ILikePlayingGames/line-diff-action#options