### PR TITLE
feat: fetch fresh uuids from leaderboards instead of hardcoded list

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,23 @@ async function get(url) {
   }
 }
 
+const leaderboardValues = {};
+
+async function getEntryValues(entry) {
+  const leaderboard = entry.valuesLeaderboard;
+  if (!leaderboard) return entry.values;
+
+  if (!leaderboardValues[leaderboard]) {
+    const data = await get(`https://api.eliteskyblock.com/leaderboard/${leaderboard}?limit=100`);
+    leaderboardValues[leaderboard] = data?.entries
+      ?.sort(() => Math.random() - 0.5)
+      .slice(0, 10)
+      .map((entry) => entry.uuid);
+  }
+
+  return leaderboardValues[leaderboard]?.length === 10 ? leaderboardValues[leaderboard] : entry.values;
+}
+
 const tasks = [
   {
     name: 'Generate API resources',
@@ -62,7 +79,8 @@ const tasks = [
         if (Object.hasOwn(entry, 'values')) {
           // Load previous data
           obj = require(path) || {};
-          for (const value of entry.values) {
+          const values = await getEntryValues(entry);
+          for (const value of values) {
             results.push(await get(url.replace('VALUE', value), type));
           }
         } else {

--- a/index.js
+++ b/index.js
@@ -54,11 +54,22 @@ async function getEntryValues(entry) {
   if (!leaderboard) return entry.values;
 
   if (!leaderboardValues[leaderboard]) {
-    const data = await get(`https://api.eliteskyblock.com/leaderboard/${leaderboard}?limit=100`);
-    leaderboardValues[leaderboard] = data?.entries
+    const url = `https://api.eliteskyblock.com/leaderboard/${leaderboard}`;
+    const [data, ironmanData] = await Promise.all([
+      get(`${url}?limit=100`),
+      get(`${url}?limit=20&mode=ironman`)
+    ]);
+    // Grab 7 UUIDs and 3 guaranteed ironman UUIDs
+    const ironmanValues = ironmanData?.entries
       ?.sort(() => Math.random() - 0.5)
-      .slice(0, 10)
+      .slice(0, 3)
       .map((entry) => entry.uuid);
+    const generalValues = data?.entries
+      ?.filter((entry) => !ironmanValues?.includes(entry.uuid))
+      .sort(() => Math.random() - 0.5)
+      .slice(0, 7)
+      .map((entry) => entry.uuid);
+    leaderboardValues[leaderboard] = [...(ironmanValues || []), ...(generalValues || [])];
   }
 
   return leaderboardValues[leaderboard]?.length === 10 ? leaderboardValues[leaderboard] : entry.values;

--- a/urls.js
+++ b/urls.js
@@ -1,20 +1,37 @@
+const fallbackPlayerUuids = [
+  '5409757b87344c0394b10bf966a2d594', // huntz
+  '3abe2f6bd45a4e2282d4f9014569db25', // anrie
+  '1f15c58cdf3c419bba39b89e256d8a86', // Chevio
+  '31b5211af8b64ea8abc6b16d6dddb07b', // Nemqnja
+  '9cc15d802eb44f2aaf2075604ce452d5', // Dexyz
+  'b26feed824264432b765dd64c3ab0ff8', // Tyler_P13
+  'f025c1c7f55a4ea0b8d93f47d17dfe0f', // Plancke
+  '20934ef9488c465180a78f861586b4cf', // Minikloon
+  'ef962ec2df6e48a2ac9d6062c1b84652', // builder_247
+  '04cd3f240c7f42009b3398fba995c3a6', // Ealman
+];
+
+const fallbackProfileUuids = [
+  'd05a0e80fa024f5a9367ca66135b7347', // LeaPhant/Grapes (Ironman)
+  '683a9f50cc9146f7b752839165c1245e', // Akinsoft/Not Allowed To Quit Skyblock Ever Again
+  // '64722047f9b34e69b67b76a62351eb05', // Technoblade/Mango
+  '739c8592161c47d2a61f25f246041967', // ThirtyVirus/Strawberry (Ironman)
+  'd3df3cccffd3473fbbba311d5329bd25', // Refraction/Apple
+  'fb3d96498a5b4d5b91b763db14b195ad', // DeathStreeks/Blueberry
+  '1277d71f338046e298d90c9fe4055f00', // 56ms/Strawberry
+  '7c207917505f4b48bab6631f2953151f', // Dueces/Kiwi
+  'a7da9276d9fa49a18e770a0509584780', // TheOriginalAce/Mango
+  'cf8e438488834985bae1749013de6db1', // 15h/Coconut
+  'fad90e13ff44441c8c5e1dbe489fd44f', // Nemqnja/Tomato
+];
+
 module.exports = [
   // API
   {
     url: "https://api.hypixel.net/v2/player?key=KEY&uuid=VALUE",
     type: 'player',
-    values: [
-      '5409757b87344c0394b10bf966a2d594', // huntz
-      '3abe2f6bd45a4e2282d4f9014569db25', // anrie
-      '1f15c58cdf3c419bba39b89e256d8a86', // Chevio
-      '31b5211af8b64ea8abc6b16d6dddb07b', // Nemqnja
-      '9cc15d802eb44f2aaf2075604ce452d5', // Dexyz
-      'b26feed824264432b765dd64c3ab0ff8', // Tyler_P13
-      'f025c1c7f55a4ea0b8d93f47d17dfe0f', // Plancke
-      '20934ef9488c465180a78f861586b4cf', // Minikloon
-      'ef962ec2df6e48a2ac9d6062c1b84652', // builder_247
-      '04cd3f240c7f42009b3398fba995c3a6', // Ealman
-    ],
+    values: fallbackPlayerUuids,
+    valuesLeaderboard: 'skyblockxp',
   },
   /*
   {
@@ -50,19 +67,8 @@ module.exports = [
   {
     url: "https://api.hypixel.net/v2/skyblock/profile?key=KEY&profile=VALUE",
     type: 'skyblock_profile_v2',
-    values: [
-      'd05a0e80fa024f5a9367ca66135b7347', // LeaPhant/Grapes (Ironman)
-      '683a9f50cc9146f7b752839165c1245e', // Akinsoft/Not Allowed To Quit Skyblock Ever Again
-      // '64722047f9b34e69b67b76a62351eb05', // Technoblade/Mango
-      '739c8592161c47d2a61f25f246041967', // ThirtyVirus/Strawberry (Ironman)
-      'd3df3cccffd3473fbbba311d5329bd25', // Refraction/Apple
-      'fb3d96498a5b4d5b91b763db14b195ad', // DeathStreeks/Blueberry
-      '1277d71f338046e298d90c9fe4055f00', // 56ms/Strawberry
-      '7c207917505f4b48bab6631f2953151f', // Dueces/Kiwi
-      'a7da9276d9fa49a18e770a0509584780', // TheOriginalAce/Mango
-      'cf8e438488834985bae1749013de6db1', // 15h/Coconut
-      'fad90e13ff44441c8c5e1dbe489fd44f', // Nemqnja/Tomato
-    ],
+    values: fallbackProfileUuids,
+    valuesLeaderboard: 'garden',
     transform: (obj, { merge, uniqueArrayElements }) => {
       let uuid = {};
       Object.keys(obj.profile.members).forEach(profile => {
@@ -79,19 +85,8 @@ module.exports = [
   {
     url: "https://api.hypixel.net/v2/skyblock/garden?key=KEY&profile=VALUE",
     type: 'skyblock_garden',
-    values: [
-      'd05a0e80fa024f5a9367ca66135b7347', // LeaPhant/Grapes (Ironman)
-      '683a9f50cc9146f7b752839165c1245e', // Akinsoft/Not Allowed To Quit Skyblock Ever Again
-      // '64722047f9b34e69b67b76a62351eb05', // Technoblade/Mango
-      '739c8592161c47d2a61f25f246041967', // ThirtyVirus/Strawberry (Ironman)
-      'd3df3cccffd3473fbbba311d5329bd25', // Refraction/Apple
-      'fb3d96498a5b4d5b91b763db14b195ad', // DeathStreeks/Blueberry
-      '1277d71f338046e298d90c9fe4055f00', // 56ms/Strawberry
-      '7c207917505f4b48bab6631f2953151f', // Dueces/Kiwi
-      'a7da9276d9fa49a18e770a0509584780', // TheOriginalAce/Mango
-      'cf8e438488834985bae1749013de6db1', // 15h/Coconut
-      'fad90e13ff44441c8c5e1dbe489fd44f', // Nemqnja/Tomato
-    ],
+    values: fallbackProfileUuids,
+    valuesLeaderboard: 'garden',
   },
   {
     url: "https://api.hypixel.net/v2/guild?key=KEY&id=VALUE",


### PR DESCRIPTION
I don't know if you guys *want* to do this, but I think this would be way better than the current list of players that is probably mostly outdated.

This fetches two leaderboards from my API:

- Skyblock XP: https://eliteskyblock.com/leaderboard/skyblockxp
- Garden: https://eliteskyblock.com/leaderboard/garden
  - Used to get profile ids (I don't expose them in normal member leaderboards)
  
It's setup to fetch the top 100 players from each and randomly select 10 uuids to fetch, which should give pretty decent coverage of players over time.